### PR TITLE
Add activation key

### DIFF
--- a/app/controllers/activation_controller.rb
+++ b/app/controllers/activation_controller.rb
@@ -1,0 +1,22 @@
+class ActivationController < ApplicationController
+
+  def new
+    if activation_params
+      user = User.find_by(activation_params)
+      user.update_attribute(:status, "active")
+      session[:user_id] = user.id
+      redirect_to activate_success_path
+    else
+      render :show
+    end
+  end
+
+  def show
+  end
+
+  private
+
+  def activation_params
+    params.permit(:activation_key)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  helper_method :current_user
 
   def current_user
-    current_user ||= User.find(session[:user_id]) if session[:user_id]
+    @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  def current_user
+    current_user ||= User.find(session[:user_id]) if session[:user_id]
+  end
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -6,8 +6,9 @@ class UserController < ApplicationController
   def create
     user = User.new(user_params)
     if user.save!
-      ActivationMailer.activation_email(user).deliver_now
       session[:user_id] = user.id
+      user.update(create_activation_key(user))
+      ActivationMailer.activation_email(user).deliver_now
       redirect_to dashboard_path
     else
       render :new
@@ -22,5 +23,9 @@ class UserController < ApplicationController
 
     def user_params
       params.permit(:name, :email, :password, :password_confirmation)
+    end
+
+    def create_activation_key(user)
+      {activation_key: (rand(10 ** 20).to_s + (user.id).to_s)}
     end
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,16 +1,21 @@
 class UserController < ApplicationController
+
+  def new
+  end
+
   def create
     user = User.new(user_params)
     if user.save!
       ActivationMailer.activation_email(user).deliver_now
       session[:user_id] = user.id
-      redirect_to "/dashboard"
+      redirect_to dashboard_path
     else
       render :new
     end
   end
 
   def show
+    @user = current_user
   end
 
   private

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,5 +1,4 @@
 class WelcomeController < ApplicationController
   def index
-    @user = User.new
   end
 end

--- a/app/mailers/activation_mailer.rb
+++ b/app/mailers/activation_mailer.rb
@@ -3,7 +3,7 @@ class ActivationMailer < ApplicationMailer
 
   def activation_email(user)
     @user = user
-    @url = 'https://command-battleshift.herokuapp.com/activate'
+    @url = activate_url
     mail(to: @user.email, subject: 'Welcome! Please complete registration') do |format|
       format.text
       format.html

--- a/app/mailers/activation_mailer.rb
+++ b/app/mailers/activation_mailer.rb
@@ -1,5 +1,5 @@
 class ActivationMailer < ApplicationMailer
-  default from: 'notifications@example.com'
+  default from: 'registration@battleshift.com'
 
   def activation_email(user)
     @user = user
@@ -7,6 +7,6 @@ class ActivationMailer < ApplicationMailer
     mail(to: @user.email, subject: 'Welcome! Please complete registration') do |format|
       format.text
       format.html
-    end 
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
   has_secure_password
-  validates_presence_of :name, :email, :password, :password_confirmation
+  validates_presence_of :name, :email, :password, :status
+  enum status: ["inactive", "active"]
 end

--- a/app/views/activation/show.html.erb
+++ b/app/views/activation/show.html.erb
@@ -1,0 +1,5 @@
+<% if current_user.status == 'active' %>
+  <p>Thank you! Your account is now activated.</p>
+  <% else %>
+  <p>You must first activate your account</p>
+<% end %>

--- a/app/views/activation_mailer/activation_email.html.erb
+++ b/app/views/activation_mailer/activation_email.html.erb
@@ -5,8 +5,6 @@
   </head>
   <body>
     <h1>Welcome <%= @user.name %> to command-battleshift! Just one more step and you're in.</h1>
-    <p>Visit here to activate your account.<br>
-      <%= @url %>
-    </p>
+    <%= link_to "Visit here to activate your account.", @url + {activation_key: "#{@user.activation_key}"}.to_param %>
   </body>
 </html>

--- a/app/views/activation_mailer/activation_email.html.erb
+++ b/app/views/activation_mailer/activation_email.html.erb
@@ -4,7 +4,7 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <h1>Welcome to command-battleshift. Just one more step and you're in.</h1>
+    <h1>Welcome <%= @user.name %> to command-battleshift! Just one more step and you're in.</h1>
     <p>Visit here to activate your account.<br>
       <%= @url %>
     </p>

--- a/app/views/activation_mailer/activation_email.text.erb
+++ b/app/views/activation_mailer/activation_email.text.erb
@@ -1,5 +1,4 @@
 Welcome to command-battleshift. Just one more step and you're in.
 ===============================================
 
-Visit here to activate your account.
-<%= @url %>
+<%= link_to "Visit here to activate your account.", @url + {activation_key: "#{@user.activation_key}"}.to_param %>

--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -1,2 +1,2 @@
-<h1>Logged in as katy</h1>
+<h1>Logged in as <%= @user.name %></h1>
 <h1>This account has not yet been activated. Please check your email.</h1>

--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -1,2 +1,6 @@
-<h1>Logged in as <%= @user.name %></h1>
-<h1>This account has not yet been activated. Please check your email.</h1>
+<% if current_user.inactive? %>
+  <h1>Logged in as <%= @user.name %></h1>
+  <h1>This account has not yet been activated. Please check your email.</h1>
+<% else %>
+  <p>Status: Active</p>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,6 +31,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { :host => "http://localhost:3000" }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,7 @@
 Rails.application.configure do
+
+  config.action_mailer.default_url_options = { :host => "https://command-battleshift.herokuapp.com" }
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.action_mailer.default_url_options = { :host => "http://localhost:3000" }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,9 @@ Rails.application.routes.draw do
   get "/register", to: "user#new"
   post "/register", to: "user#create"
   get "/dashboard", to: "user#show"
-  
-  get "/activate", as: "activate", to: "activation#new"
+
+  get "/activate", to: "activation#new"
+  get "/activate-success", as: "activate_success", to: "activation#show"
 
   namespace :api do
     namespace :v1 do

--- a/db/migrate/20180327041012_add_activation_key_to_user.rb
+++ b/db/migrate/20180327041012_add_activation_key_to_user.rb
@@ -1,0 +1,5 @@
+class AddActivationKeyToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :activation_key, :string
+  end
+end

--- a/db/migrate/20180327043903_add_status_to_users.rb
+++ b/db/migrate/20180327043903_add_status_to_users.rb
@@ -1,0 +1,5 @@
+class AddStatusToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180326210304) do
+ActiveRecord::Schema.define(version: 20180327043903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,8 @@ ActiveRecord::Schema.define(version: 20180326210304) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "activation_key"
+    t.integer "status", default: 0
   end
 
 end

--- a/spec/features/user_can_activate_account_through_email_spec.rb
+++ b/spec/features/user_can_activate_account_through_email_spec.rb
@@ -1,14 +1,12 @@
-# Background: The registration process will trigger this story
-
 require 'rails_helper'
 
 describe "As a non-activated user" do
-  scenario "When I check my email for the registration email" do
+  scenario "I complete my registration through an email link" do
     visit root_path
 
     click_on "Register"
 
-    expect(current_path).to eq("/register")
+    expect(current_path).to eq(register_path)
 
     fill_in "email", with: "katy.jane8@gmail.com"
     fill_in "name", with: "katy"
@@ -20,18 +18,15 @@ describe "As a non-activated user" do
     email = ActionMailer::Base.deliveries.last
     expect(email.subject).to have_content("Welcome! Please complete registration")
     expect(email).to have_content("Visit here to activate your account.")
-  end
+    expect(User.last).to have_attribute(:activation_key)
 
-  scenario "I finish registration" do
-    user = create(:user)
+    visit activate_path(activation_key: User.last.activation_key)
 
-    visit "https://command-battleshift.herokuapp.com/activate"
+    expect(current_path).to eq(activate_success_path)
+    expect(page).to have_content("Thank you! Your account is now activated.")
 
-    
-    # And when I click on that link
-    # Then I should be taken to a page that says "Thank you! Your account is now activated."
-    #
-    # And when I visit "/dashboard"
-    # Then I should see "Status: Active"
+    visit dashboard_path
+
+    expect(page).to have_content("Status: Active")
   end
 end

--- a/spec/features/user_can_register_for_account_spec.rb
+++ b/spec/features/user_can_register_for_account_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+
 describe "as a guest user" do
   scenario "when I visit the root, I can register as a user" do
     visit root_path

--- a/spec/features/user_can_register_for_gameplay_spec.rb
+++ b/spec/features/user_can_register_for_gameplay_spec.rb
@@ -5,7 +5,7 @@ describe "as a guest user" do
 
     click_on "Register"
 
-    expect(current_path).to eq("/register")
+    expect(current_path).to eq(register_path)
 
     fill_in "email", with: "user@user.com"
     fill_in(:name, with: "katy")
@@ -14,7 +14,7 @@ describe "as a guest user" do
 
     click_on "Submit"
 
-    expect(current_path).to eq("/dashboard")
+    expect(current_path).to eq(dashboard_path)
     expect(page).to have_content("Logged in as katy")
     expect(page).to have_content("This account has not yet been activated. Please check your email.")
   end

--- a/spec/mailers/activation_mailer_spec.rb
+++ b/spec/mailers/activation_mailer_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe ActivationMailer, type: :mailer do
+  it "Sends activation email to user" do
+    ActionMailer::Base.deliveries.should be_empty
+
+    user = create(:user)
+    ActivationMailer.activation_email(user).deliver
+
+    ActionMailer::Base.deliveries.should_not be_empty
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,11 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe UserMailer, type: :mailer do
-  it "invite user to join the site" do
+describe UserMailer, type: :mailer do
+  it "Sends welcome email to user" do
     ActionMailer::Base.deliveries.should be_empty
 
     user = create(:user)
     UserMailer.welcome_email(user).deliver
+
     ActionMailer::Base.deliveries.should_not be_empty
   end
 end


### PR DESCRIPTION
Added functionality for user to activate account through email using an activation key. Added activation key on the User model.

Needs to be refactored. Some thoughts:

- [ ] 1. Is a 'get' request the best way for a user to activate their account? I was thinking post or patch originally because when they click the activate link they would be updating their own user attribute status, as well as be creating a new API key.
- [ ] 2. Is creating an ActivationController new and show actions the most RESTful way to go through the process of activation?
- [ ] 3. Is using a Capybara 'visit' the best way to test a user clicking on a link from their email??
- [ ] 4. Do we need to hide user's activation keys using Figaro?
- [ ] 5. Can we break out any of the long controller methods into services, modules or helper methods?
- [ ] 6. The server tells me the email is being sent and all tests are passing... however when I run the server I never receive an email :(